### PR TITLE
ffstools: use separate keyspaces for roots and non-root blobs

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -30,6 +30,7 @@ type settings struct {
 
 	// Flag targets
 	Store     string // global
+	Bucket    string // global
 	Debug     bool   // global
 	Replace   bool   // put
 	Raw       bool   // list
@@ -66,6 +67,7 @@ otherwise -store must be set.
 	SetFlags: func(env *command.Env, fs *flag.FlagSet) {
 		cfg := env.Config.(*settings)
 		fs.StringVar(&cfg.Store, "store", os.Getenv("BLOB_STORE"), "Blob store address (required)")
+		fs.StringVar(&cfg.Bucket, "bucket", "", "Prefix to add to all keys")
 		fs.BoolVar(&cfg.Debug, "debug", false, "Enable client debug logging")
 	},
 

--- a/ffs/internal/cmdexport/cmdexport.go
+++ b/ffs/internal/cmdexport/cmdexport.go
@@ -190,12 +190,12 @@ func linkFile(ctx context.Context, f *file.File, path string) error {
 }
 
 func openFile(ctx context.Context, s blob.CAS, spec string) (*file.File, error) {
-	if strings.HasPrefix(spec, "root:") {
-		rp, err := root.Open(ctx, s, spec)
+	if strings.HasPrefix(spec, "@") {
+		rp, err := root.Open(ctx, config.Roots(s), spec[1:])
 		if err != nil {
 			return nil, err
 		}
-		return rp.File(ctx)
+		return rp.File(ctx, s)
 	}
 	key, err := config.ParseKey(spec)
 	if err != nil {

--- a/ffs/internal/cmdfile/cmdfile.go
+++ b/ffs/internal/cmdfile/cmdfile.go
@@ -42,7 +42,7 @@ var Command = &command.C{
 File objects are addressed by storage keys. The storage key for
 a file may be specified in the following formats:
 
-  root:<root-name>              : the file key from a root pointer
+  @<root-name>                 : the file key from a root pointer
   74686973206973206d79206b6579  : hexadecimal encoded
   dGhpcyBpcyBteSBrZXk=          : base64 encoded
 `,
@@ -235,17 +235,17 @@ func (o *openInfo) flushRoot(ctx context.Context, s blob.CAS) (string, error) {
 func openFile(ctx context.Context, s blob.CAS, spec string, path ...string) (*openInfo, error) {
 	var out openInfo
 
-	if strings.HasPrefix(spec, "root:") {
-		rp, err := root.Open(ctx, s, spec)
+	if strings.HasPrefix(spec, "@") {
+		rp, err := root.Open(ctx, config.Roots(s), spec[1:])
 		if err != nil {
 			return nil, err
 		}
-		rf, err := rp.File(ctx)
+		rf, err := rp.File(ctx, s)
 		if err != nil {
 			return nil, err
 		}
 		out.root = rp
-		out.rootKey = spec
+		out.rootKey = spec[1:]
 		out.rootFile = rf
 		out.targetKey = rp.FileKey
 	} else if fk, err := config.ParseKey(spec); err != nil {

--- a/ffs/internal/cmdfile/cmdfile.go
+++ b/ffs/internal/cmdfile/cmdfile.go
@@ -32,7 +32,7 @@ import (
 	"github.com/creachadair/ffstools/ffs/config"
 )
 
-const fileCmdUsage = `root:<root-key>[/path] ...
+const fileCmdUsage = `@<root-key>[/path] ...
 <file-key>[/path] ...`
 
 var Command = &command.C{
@@ -64,7 +64,7 @@ a file may be specified in the following formats:
 		},
 		{
 			Name: "set",
-			Usage: `root:<root-key>/<path> <target-key>
+			Usage: `@<root-key>/<path> <target-key>
 <origin-key>/<path> <file-key>`,
 			Help: `Set the specified path beneath the origin to the given target
 
@@ -76,7 +76,7 @@ If the origin is from a root, the root is updated with the modified origin.
 		},
 		{
 			Name: "remove",
-			Usage: `root:<root-key>/<path> ...
+			Usage: `@<root-key>/<path> ...
 <origin-key>/<path> ...`,
 			Help: `Remove the specified path from beneath the origin
 

--- a/ffs/internal/cmdgc/cmdgc.go
+++ b/ffs/internal/cmdgc/cmdgc.go
@@ -36,11 +36,8 @@ var Command = &command.C{
 	Usage: "<root-key> <root-key>...",
 	Help:  "Garbage-collect blobs not reachable from known roots",
 
-	Run: func(env *command.Env, args []string) error {
-		keys, err := config.RootKeys(args)
-		if err != nil {
-			return err
-		} else if len(keys) == 0 {
+	Run: func(env *command.Env, keys []string) error {
+		if len(keys) == 0 {
 			return errors.New("at least one root key is required")
 		}
 
@@ -60,7 +57,7 @@ var Command = &command.C{
 			// Mark phase: Scan all roots.
 			for i := 0; i < len(keys); i++ {
 				key := keys[i]
-				rp, err := root.Open(cfg.Context, s, key)
+				rp, err := root.Open(cfg.Context, config.Roots(s), key)
 				if err != nil {
 					return fmt.Errorf("opening %q: %w", key, err)
 				}
@@ -93,7 +90,7 @@ var Command = &command.C{
 
 				// Otherwise, we need to compute the reachable set.
 				// TODO(creachadair): Maybe cache the results here too.
-				rf, err := rp.File(cfg.Context)
+				rf, err := rp.File(cfg.Context, s)
 				if err != nil {
 					return fmt.Errorf("opening %q: %w", rp.FileKey, err)
 				}

--- a/ffs/internal/cmdindex/cmdindex.go
+++ b/ffs/internal/cmdindex/cmdindex.go
@@ -40,11 +40,8 @@ var Command = &command.C{
 		fs.BoolVar(&indexFlags.Force, "f", false, "Force reindexing")
 	},
 
-	Run: func(env *command.Env, args []string) error {
-		keys, err := config.RootKeys(args)
-		if err != nil {
-			return err
-		} else if len(keys) == 0 {
+	Run: func(env *command.Env, keys []string) error {
+		if len(keys) == 0 {
 			return env.Usagef("missing required <root-key>")
 		}
 
@@ -55,7 +52,7 @@ var Command = &command.C{
 				return err
 			}
 			for _, key := range keys {
-				rp, err := root.Open(cfg.Context, s, key)
+				rp, err := root.Open(cfg.Context, config.Roots(s), key)
 				if err != nil {
 					return err
 				}
@@ -63,7 +60,7 @@ var Command = &command.C{
 					fmt.Fprintf(env, "Root %q is already indexed\n", key)
 					continue
 				}
-				fp, err := rp.File(cfg.Context)
+				fp, err := rp.File(cfg.Context, s)
 				if err != nil {
 					return err
 				}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/creachadair/boltstore v0.0.0-20220427000910-2ac5e1047ef6
 	github.com/creachadair/command v0.0.0-20220426235536-a748effdf6a1
 	github.com/creachadair/ctrl v0.1.1
-	github.com/creachadair/ffs v0.0.0-20220426235939-589f835c0a18
+	github.com/creachadair/ffs v0.0.0-20220430184118-7039c6d6dbff
 	github.com/creachadair/gcsstore v0.0.0-20220427000936-95cda7992a29
 	github.com/creachadair/jrpc2 v0.39.0
 	github.com/creachadair/keyfile v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/creachadair/command v0.0.0-20220426235536-a748effdf6a1 h1:r626P+s8TKp
 github.com/creachadair/command v0.0.0-20220426235536-a748effdf6a1/go.mod h1:bAM+qFQb/KwWyCc9MLC4U1jvn3XyakqP5QRkds5T6cY=
 github.com/creachadair/ctrl v0.1.1 h1:sztvK/haLnCSL1IY4mFxEgg5ksAvQMRUFcjB0EeuGY0=
 github.com/creachadair/ctrl v0.1.1/go.mod h1:QORxQsErPqDEuQxtRDa907Chq+IwJUkMAhkHFsphops=
-github.com/creachadair/ffs v0.0.0-20220426235939-589f835c0a18 h1:Dh63wjhwc4T2470ORELiCD3lKXgurs+vc5gDel55bbs=
-github.com/creachadair/ffs v0.0.0-20220426235939-589f835c0a18/go.mod h1:ottLToKvJuqMagZbm4zTcMOZEhlydZ3AHqPGrO+Uobk=
+github.com/creachadair/ffs v0.0.0-20220430184118-7039c6d6dbff h1:feGyss5Hp6l38oSULYt+tlCTjLQR2rk8dqh+dUWibv0=
+github.com/creachadair/ffs v0.0.0-20220430184118-7039c6d6dbff/go.mod h1:4sN5QJ+aSvS//YBpOc6hH+4dMo9WQ19pfQjaj1SwvJQ=
 github.com/creachadair/gcsstore v0.0.0-20220427000936-95cda7992a29 h1:0M+JshSgDbmvrYjkzokloH9cwys10bbDoSzI9Z/AbOw=
 github.com/creachadair/gcsstore v0.0.0-20220427000936-95cda7992a29/go.mod h1:BxV88oqLOCScdky7aC5855qTNghWRapTmhPtTwrldGk=
 github.com/creachadair/jrpc2 v0.39.0 h1:utYrIm5y4TRd5svlE95RS2rRWNh88uXQnqmadgcMVDI=


### PR DESCRIPTION
Use prefixed store wrappers to partition the keys for roots from
the keys for other blobs. Roots now begin with "@" and other keys
begin with " " (space).

This generalizes the existing convention that keys beginning with
the string "root:" were supposed to be root blobs. That works fine
as long as we are lucky, but is not very robust.

Related changes:

- Add a -bucket global flag to the blob tool.
- Update the ffs module to import prefixed package improvements.
- Update the ffs config package to support prefixes.
- Update ffs subcommands to be aware of the prefixed storage.