### PR TITLE
Fold the "blob" tool into a subcommand of ffs.

### DIFF
--- a/.go-update
+++ b/.go-update
@@ -4,7 +4,6 @@ update_mod() {
 }
 
 cleanup() {
-    go install github.com/creachadair/ffstools/blob
     go install github.com/creachadair/ffstools/ffs
     go install github.com/creachadair/ffstools/file2json
     go install -tags gcs,pebble,s3 github.com/creachadair/ffstools/blobd

--- a/README.md
+++ b/README.md
@@ -11,15 +11,6 @@ See also https://github.com/creachadair/ffs.
   go install github.com/creachadair/ffstools/blobd@latest
   ```
 
-- The [`blob`](https://github.com/creachadair/ffstools/tree/main/blob) tool
-  is a client that communicates with the `blobd` service to manipulate the
-  contents of a blob store as opaque data.
-
-  ```sh
-  # To install:
-  go install github.com/creachadair/ffstools/blob@latest
-  ```
-
 - The [`ffs`](https://github.com/creachadair/ffstools/tree/main/ffs) tool
   also communicates with the `blobd` service and provides commands to
   manipulate the contents of the store as FFS specific messages.
@@ -28,6 +19,8 @@ See also https://github.com/creachadair/ffs.
   # To install:
   go install github.com/creachadair/ffstools/ffs@latest
   ```
+
+  The `ffs blob` subcommand replaced the separate `blob` tool in #30.
 
 - The [`file2json`](https://github.com/creachadair/ffstools/tree/main/file2json)
   tool decodes wire-format node messages and translates them to JSON for easier

--- a/ffs/ffs.go
+++ b/ffs/ffs.go
@@ -25,6 +25,7 @@ import (
 	"github.com/creachadair/ffstools/ffs/config"
 
 	// Subcommands.
+	"github.com/creachadair/ffstools/ffs/internal/cmdblob"
 	"github.com/creachadair/ffstools/ffs/internal/cmdexport"
 	"github.com/creachadair/ffstools/ffs/internal/cmdfile"
 	"github.com/creachadair/ffstools/ffs/internal/cmdgc"
@@ -73,6 +74,7 @@ help [<command>]`,
 		},
 
 		Commands: []*command.C{
+			cmdblob.Command,
 			cmdroot.Command,
 			cmdfile.Command,
 			cmdput.Command,


### PR DESCRIPTION
Because it started before "ffs" existed, the "blob" tool had its own separate
implementations of most of what the ffs/config package now handles. Eliminate
the special case by moving it to be a subcommand of "ffs".

To the extent practical the functionality is not changed; the main difference
so far is I collapsed "cas put" and "cas key" into "cas-put" and "cas-key"
under "blob" rather than keeping a separate subheading, and removed the now
redundant "status" and "version" blob subcommands.
