### PR TITLE
ffs: allow configuring the storage service method prefix

### DIFF
--- a/ffs/ffs.go
+++ b/ffs/ffs.go
@@ -40,9 +40,10 @@ import (
 )
 
 var (
-	configPath = config.Path()
-	storeAddr  string
-	debugLog   bool
+	configPath  = config.Path()
+	storeAddr   string
+	storePrefix string
+	debugLog    bool
 )
 
 func main() {
@@ -55,6 +56,7 @@ help [<command>]`,
 		SetFlags: func(env *command.Env, fs *flag.FlagSet) {
 			fs.StringVar(&configPath, "config", configPath, "Configuration file path")
 			fs.StringVar(&storeAddr, "store", storeAddr, "Store service address (overrides config and environment)")
+			fs.StringVar(&storePrefix, "prefix", storePrefix, "Store service prefix (overrides config and environment)")
 			fs.BoolVar(&debugLog, "debug", debugLog, "Enable debug logging (warning: noisy)")
 		},
 
@@ -67,6 +69,11 @@ help [<command>]`,
 				cfg.DefaultStore = storeAddr
 			} else if bs := os.Getenv("FFS_STORE"); bs != "" {
 				cfg.DefaultStore = bs
+			}
+			if storePrefix != "" {
+				cfg.DefaultPrefix = storePrefix
+			} else if sp := os.Getenv("FFS_PREFIX"); sp != "" {
+				cfg.DefaultPrefix = sp
 			}
 			if debugLog {
 				cfg.EnableDebugLogging = true
@@ -102,6 +109,7 @@ FFS_CONFIG     : Configuration file path (default: ` + config.DefaultPath + `)
 FFS_DEBUG      : If true, enable debug logging (warning: noisy)
 FFS_PASSPHRASE : If set, contains the passphrase for a --key file
 FFS_STORE      : Storage service address (overrides config; overridden by --store)
+FFS_PREFIX     : Storage service method name prefix (overrides config; overridden by --prefix)
 `,
 			}}),
 			command.VersionCommand(),

--- a/ffs/internal/cmdstorage/start.go
+++ b/ffs/internal/cmdstorage/start.go
@@ -55,6 +55,7 @@ type startConfig struct {
 	Address string
 	Spec    string
 	Store   blob.CAS
+	Prefix  string
 	Buffer  blob.Store
 }
 
@@ -73,7 +74,7 @@ func startChirpServer(ctx context.Context, opts startConfig) (closer, *taskgroup
 	}
 	log.Printf("[chirp] Service: %q", opts.Address)
 
-	service := chirpstore.NewService(opts.Store, nil)
+	service := chirpstore.NewService(opts.Store, &chirpstore.ServiceOpts{Prefix: opts.Prefix})
 	mx := newServerMetrics(ctx, opts)
 	loop := taskgroup.Go(func() error {
 		return peers.Loop(ctx, peers.NetAccepter(lst), func() *chirp.Peer {

--- a/ffs/internal/cmdsync/cmdsync.go
+++ b/ffs/internal/cmdsync/cmdsync.go
@@ -74,9 +74,8 @@ func runSync(env *command.Env, sourceKeys ...string) error {
 
 	cfg := env.Config.(*config.Settings)
 	return cfg.WithStore(env.Context(), func(src config.CAS) error {
-		taddr := cfg.ResolveAddress(syncFlags.Target)
-		return cfg.WithStoreAddress(env.Context(), taddr, func(tgt config.CAS) error {
-			fmt.Fprintf(env, "Target store: %q\n", taddr)
+		return cfg.WithStoreAddress(env.Context(), syncFlags.Target, func(tgt config.CAS) error {
+			fmt.Fprintf(env, "Target store: %q\n", syncFlags.Target)
 
 			// Find all the objects reachable from the specified starting points.
 			worklist := scanlib.NewScanner(src)


### PR DESCRIPTION
To allow a storage service to share a peer with other things, expose the prefix
options via flags. This required a bit of reworking of the config package.
